### PR TITLE
bugfix: parse filename contain Spaces

### DIFF
--- a/scp.go
+++ b/scp.go
@@ -357,7 +357,7 @@ func scpReadCommand(src *bufio.Reader) (string, error) {
 // Parse the SCP command
 func parseSCPCommand(cmd string) (*SCPCommand, error) {
 	parsePieces := func(cstr string, c *SCPCommand) error {
-		pieces := strings.Split(cmd, " ")
+		pieces := strings.SplitN(cmd, " ", 3)
 		if len(pieces) != 3 {
 			return ErrInvalidPieces
 		}


### PR DESCRIPTION
if the filename contain spaces, string.Split(cmd) will split filename and the program go to ErrInvalidPieces. Use string.SplitN to ensure not split filename.