### PR TITLE
execute handleConn in goroutine to make it non-blocking

### DIFF
--- a/server.go
+++ b/server.go
@@ -19,10 +19,11 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"net"
 	"strconv"
+
+	"golang.org/x/crypto/ssh"
 )
 
 // Manage the SSH Server
@@ -105,7 +106,7 @@ func (s *Server) serveLoop() error {
 		select {
 		case conn, ok := <-acceptChan:
 			if ok {
-				s.handleConn(conn)
+				go s.handleConn(conn)
 			} else {
 				dbg.Debug("failed to accept")
 				acceptChan = nil


### PR DESCRIPTION
hi,

handleConn is not executed as go routine, potentially blocking any other connection if an handshake does not finish.
So any sshd instance is easily DoS'able :-)
How to reproduce?

Use netcat to connect:
```

  nc localhost 2222
SSH-2.0-Go
```

while this connection is open, it blocks all other connections to the sshd. Calling handleConn as go routine fixes this.
See also: https://github.com/golang/go/issues/43521