### PR TITLE
close stdin, otherwise piping to executed commands hangs

### DIFF
--- a/serverconn.go
+++ b/serverconn.go
@@ -17,9 +17,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/google/shlex"
-	"github.com/matir/sshdog/pty"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"net"
 	"os"
@@ -27,6 +24,10 @@ import (
 	"os/user"
 	"runtime"
 	"sync"
+
+	"github.com/google/shlex"
+	"github.com/matir/sshdog/pty"
+	"golang.org/x/crypto/ssh"
 )
 
 // Handling for a single incoming connection
@@ -242,7 +243,10 @@ func (conn *ServerConn) ExecuteForChannel(shellCmd []string, ch ssh.Channel) {
 	}
 	if conn.pty == nil {
 		stdin, _ := proc.StdinPipe()
-		go io.Copy(stdin, ch)
+		go func() {
+			defer stdin.Close()
+			io.Copy(stdin, ch)
+		}()
 		proc.Stdout = ch
 		proc.Stderr = ch
 	} else {


### PR DESCRIPTION
passing stdin to executed commands is not possible, io.Copy is executed as goroutine and stdin is never closed, thus commands such as:

` echo foo | ssh localhost -p 2222 'tee -a /tmp/file'`

will simply hang forever.

Wrap  io.Copy as goroutine, defer close stdin after copy to fix this.